### PR TITLE
[feat]: improve UX for missing or invalid EXERCISE_ID

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,11 +4,11 @@ import * as path from 'path';
 import { toggleRecording } from './speech';
 import { killLocal } from './localServer';
 import { setExtensionContext } from './localServer';
-import { 
-  syncGitRepo, 
-  getPromptContent, 
-  getTestFiles, 
-  listLocalExercises, 
+import {
+  syncGitRepo,
+  getPromptContent,
+  getTestFiles,
+  listLocalExercises,
   listLocalTemplates,
   LOCAL_REPO_PATH,
 } from './gitUtils';
@@ -29,9 +29,9 @@ import {
 } from './promptUtils';
 
 const chan = vscode.window.createOutputChannel("Jupyter AI Feedback");
-function toStr(x:any){ try{ return typeof x==='string'?x:JSON.stringify(x,(_k,v)=>v,2);}catch{ return String(x);} }
-export function log(...args:any[]){ chan.appendLine(`[${new Date().toISOString()}] ` + args.map(toStr).join(" ")); console.log(...args); }
-export function showLog(preserveFocus=true){ chan.show(preserveFocus); }
+function toStr(x: any) { try { return typeof x === 'string' ? x : JSON.stringify(x, (_k, v) => v, 2); } catch { return String(x); } }
+export function log(...args: any[]) { chan.appendLine(`[${new Date().toISOString()}] ` + args.map(toStr).join(" ")); console.log(...args); }
+export function showLog(preserveFocus = true) { chan.show(preserveFocus); }
 
 let recording = false;
 // Throttle: restrict 'CellMate.sendNotebookCell' to once per 3 seconds
@@ -773,11 +773,11 @@ async function callLLMAPI(prompt: string, config: LLMConfig): Promise<string> {
     config.apiUrl,
     body,
     {
-        headers: {
+      headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${config.apiKey}`
-        },
-        responseType: isOpenAIEndpoint ? 'json' : 'text'
+      },
+      responseType: isOpenAIEndpoint ? 'json' : 'text'
     }
   );
 
@@ -1005,44 +1005,44 @@ export function activate(ctx: vscode.ExtensionContext) {
     provideCellStatusBarItems(cell) {
       const items = [];
       if (cell.document.languageId === 'python') {
-          const cfg = vscode.workspace.getConfiguration('CellMate');
-          const alwaysShowErrorHelper = cfg.get<boolean>('errorHelper.alwaysShow', false);
+        const cfg = vscode.workspace.getConfiguration('CellMate');
+        const alwaysShowErrorHelper = cfg.get<boolean>('errorHelper.alwaysShow', false);
 
-          const cellOutput = getCellOutput(cell);
-          const hasError = cellOutput.executionError ||
-                          (cellOutput.hasOutput && cellOutput.output.toLowerCase().includes('error'));
+        const cellOutput = getCellOutput(cell);
+        const hasError = cellOutput.executionError ||
+          (cellOutput.hasOutput && cellOutput.output.toLowerCase().includes('error'));
 
-          const shouldShowErrorHelper = alwaysShowErrorHelper || hasError;
+        const shouldShowErrorHelper = alwaysShowErrorHelper || hasError;
 
-          if (shouldShowErrorHelper) {
-            const errorHelperItem = new vscode.NotebookCellStatusBarItem(
-              'Error Helper',
-              vscode.NotebookCellStatusBarAlignment.Right
-            );
-            errorHelperItem.priority = 200;
-            errorHelperItem.command = {
-              command: 'CellMate.errorHelper',
-              title: 'Error Helper',
-              arguments: [cell]
-            };
-            errorHelperItem.tooltip = hasError ?
-              'Get AI help with this error' :
-              'Get AI help with your code (no errors detected)';
-            items.push(errorHelperItem);
-          }
-
-          // Original AI Feedback button
-          const item = new vscode.NotebookCellStatusBarItem(
-            '$(zap) AI Feedback',
+        if (shouldShowErrorHelper) {
+          const errorHelperItem = new vscode.NotebookCellStatusBarItem(
+            'Error Helper',
             vscode.NotebookCellStatusBarAlignment.Right
           );
-          item.priority = 100;
-          item.command = {
-            command: 'CellMate.sendNotebookCell',
-            title: 'Send to AI',
+          errorHelperItem.priority = 200;
+          errorHelperItem.command = {
+            command: 'CellMate.errorHelper',
+            title: 'Error Helper',
             arguments: [cell]
           };
-          items.push(item);
+          errorHelperItem.tooltip = hasError ?
+            'Get AI help with this error' :
+            'Get AI help with your code (no errors detected)';
+          items.push(errorHelperItem);
+        }
+
+        // Original AI Feedback button
+        const item = new vscode.NotebookCellStatusBarItem(
+          '$(zap) AI Feedback',
+          vscode.NotebookCellStatusBarAlignment.Right
+        );
+        item.priority = 100;
+        item.command = {
+          command: 'CellMate.sendNotebookCell',
+          title: 'Send to AI',
+          arguments: [cell]
+        };
+        items.push(item);
       }
       if (cell.document.languageId === 'markdown') {
         const speechItem = new vscode.NotebookCellStatusBarItem(
@@ -1062,7 +1062,7 @@ export function activate(ctx: vscode.ExtensionContext) {
       const showAll = cfg.get<boolean>('showButtonInAllMarkdown')
       const text = cell.document.getText().toLowerCase()
       const containsFeedback = text.includes('**feedback**') || text.includes('**🤖feedback expansion**')
-      if(cell.kind === vscode.NotebookCellKind.Markup && (showAll || containsFeedback)){
+      if (cell.kind === vscode.NotebookCellKind.Markup && (showAll || containsFeedback)) {
         const cfg = vscode.workspace.getConfiguration('CellMate');
         const mode = cfg.get<string>('feedbackMode');
 
@@ -1072,13 +1072,13 @@ export function activate(ctx: vscode.ExtensionContext) {
             : '📖 Expand | ➤ Explain';
 
         const markdownItem = new vscode.NotebookCellStatusBarItem(
-        label,
-        vscode.NotebookCellStatusBarAlignment.Right
+          label,
+          vscode.NotebookCellStatusBarAlignment.Right
         );
         markdownItem.command = {
-          command : 'CellMate.explainMarkdownCell',
+          command: 'CellMate.explainMarkdownCell',
           title: 'Expand or Explain Feedback Markdown',
-          arguments:[cell]
+          arguments: [cell]
         }
         markdownItem.priority = 100;
         markdownItem.tooltip = `Use AI to ${mode} the feedback`
@@ -1172,7 +1172,7 @@ export function activate(ctx: vscode.ExtensionContext) {
 
           const possibleKeys = ['problem_description', 'problem', 'exercise_description', 'task'];
           let problemDescription = '';
-          
+
           for (const key of possibleKeys) {
             if (placeholderMap.has(key)) {
               problemDescription = placeholderMap.get(key) || '';
@@ -1200,7 +1200,7 @@ export function activate(ctx: vscode.ExtensionContext) {
             prompt = fillPromptTemplate(standardPrompt, placeholderMap, editor.notebook);
             console.log('Using standard prompt without problem description');
           }
-          
+
           console.log('Problem description found:', problemDescription ? 'Yes' : 'No');
           console.log('Problem description length:', problemDescription.length);
 
@@ -1296,7 +1296,7 @@ ${feedback}
 
         const editor = vscode.window.activeNotebookEditor;
         let problemDescription = '';
-        
+
         if (editor) {
           // Extract placeholders
           const placeholderKeys = new Set(['problem_description', 'problem', 'exercise_description', 'task']);
@@ -1388,10 +1388,22 @@ ${feedback}
         if (useHiddenTests) {
           const exId = extractExerciseId(code);
           if (!exId) {
-            vscode.window.showWarningMessage('No # EXERCISE_ID found in code');
+            const exercises = await listLocalExercises();
+            const ids = exercises.map((e: any) => e.id).join(', ');
+            vscode.window.showWarningMessage(`No # EXERCISE_ID found. Please add “# EXERCISE_ID: [ID]” in the code cell. Available IDs: ${ids || 'None'}`);
             return;
           }
-          const { test, metadata } = await getTestFiles(exId);
+
+          let testFiles;
+          try {
+            testFiles = await getTestFiles(exId);
+          } catch (e: any) {
+            const exercises = await listLocalExercises();
+            const ids = exercises.map((e: any) => e.id).join(', ');
+            vscode.window.showErrorMessage(`Exercise '${exId}' not found or invalid. Available IDs: ${ids || 'None'}`);
+            return;
+          }
+          const { test, metadata } = testFiles;
 
           // Get notebook Python path
           const pythonPath = await getNotebookPythonPath();
@@ -1413,7 +1425,7 @@ ${feedback}
             // 1) From synced repo tests folder
             const repoDataDir = path.join(LOCAL_REPO_PATH, 'tests', exId, 'data');
             resourceDirs.push(repoDataDir);
-          } catch {}
+          } catch { }
 
           // Run tests locally (with internal timeout guard and resource copy)
           const testResult = await runLocalTest(code, test, venvPython, 15000, resourceDirs);
@@ -1554,11 +1566,11 @@ ${feedback}
             apiUrl,
             body,
             {
-                headers: {
+              headers: {
                 'Content-Type': 'application/json',
                 Authorization: `Bearer ${apiKey}`
-                },
-                responseType: isOpenAIEndpoint ? 'json' : 'text'
+              },
+              responseType: isOpenAIEndpoint ? 'json' : 'text'
             }
           );
 
@@ -1748,9 +1760,9 @@ ${feedback}
     })
   );
 
-  async function replaceCellContent(doc:vscode.TextDocument, content:string){
+  async function replaceCellContent(doc: vscode.TextDocument, content: string) {
     const edit = new vscode.WorkspaceEdit();
-    const start = new vscode.Position(0,0);
+    const start = new vscode.Position(0, 0);
     const end = doc.lineAt(doc.lineCount - 1).range.end;
     const fullRange = new vscode.Range(start, end);
     edit.replace(doc.uri, fullRange, content);
@@ -1761,47 +1773,47 @@ ${feedback}
     let cleaned = text;
 
     // Remove common redundant phrases generated by LLMs
-    cleaned = cleaned.replace(/^.*?(Expanded Feedback|Feedback Expansion|Here.*feedback|Based on.*feedback).*$/gmi, '');    
+    cleaned = cleaned.replace(/^.*?(Expanded Feedback|Feedback Expansion|Here.*feedback|Based on.*feedback).*$/gmi, '');
     // Remove extra blank lines
     cleaned = cleaned.replace(/\n{3,}/g, '\n\n');
 
     // Fix unmatched markdown symbol
     const count = (str: string) => (cleaned.match(new RegExp(str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g')) || []).length;
-    
+
     // Prioritize fixing unmatched **
     if (count('\\*\\*') % 2 !== 0) cleaned += '**';
-    
+
     // Then fix single *
     const singleStarCount = count('\\*') - 2 * count('\\*\\*');
     if (singleStarCount % 2 !== 0) cleaned += '*';
-    
+
     // Fix unmatched backticks `
     if (count('`') % 2 !== 0) cleaned += '`';
 
-     // Do not touch patterns related to **
+    // Do not touch patterns related to **
     cleaned = cleaned.replace(/\\([_`#])/g, '$1');
     cleaned = cleaned.replace(/\\n/g, '\n');
 
     return cleaned.trim();
-}
+  }
 
-type ExplanationCtx = {
-  wholeFeedback?: string;    
-};
+  type ExplanationCtx = {
+    wholeFeedback?: string;
+  };
 
-const explanationStore = new Map<string, ExplanationCtx>();
+  const explanationStore = new Map<string, ExplanationCtx>();
 
-function setExplanationCtx(cellUri: string, ctx: ExplanationCtx) {
-  explanationStore.set(cellUri, ctx);
-}
-function getExplanationCtx(cellUri: string) {
-  return explanationStore.get(cellUri);
-}
+  function setExplanationCtx(cellUri: string, ctx: ExplanationCtx) {
+    explanationStore.set(cellUri, ctx);
+  }
+  function getExplanationCtx(cellUri: string) {
+    return explanationStore.get(cellUri);
+  }
   // Markdown cell
   ctx.subscriptions.push(
     vscode.commands.registerCommand(
       'CellMate.explainMarkdownCell',
-      async(cell: vscode.NotebookCell) => {
+      async (cell: vscode.NotebookCell) => {
         const editor = vscode.window.activeNotebookEditor;
         if (!editor) {
           return vscode.window.showErrorMessage('No activity')
@@ -1845,15 +1857,15 @@ function getExplanationCtx(cellUri: string) {
             return vscode.window.showErrorMessage('Please select the sentence you want explained.')
           }
           inputText = selectedText;
-          header =  `**🤖Explanation** for:**_"${selectedText}"_**`
+          header = `**🤖Explanation** for:**_"${selectedText}"_**`
         } else {
           return vscode.window.showErrorMessage(`Unsupported mode: ${mode}`);
         }
 
         await syncGitRepo()
         const promptTpl = await getPromptContent(mode);
-        
-        let prompt:string 
+
+        let prompt: string
         switch (mode) {
           case "Expand": {
             prompt = promptTpl.replace('{{content}}', inputText);
@@ -1866,7 +1878,7 @@ function getExplanationCtx(cellUri: string) {
           default:
             prompt = promptTpl;
         }
-        
+
         // extract all placeholders
         const placeholderKeys = getTemplatePlaceholderKeys(prompt);
 
@@ -1898,14 +1910,14 @@ function getExplanationCtx(cellUri: string) {
 
         try {
           const body = {
-            model : modelName,
+            model: modelName,
             prompt: prompt,
-            stream : true
+            stream: true
           };
 
           const resp = await axios.post(apiUrl, body, {
             headers: {
-              'content-Type' : 'application/json',
+              'content-Type': 'application/json',
               Authorization: `Bearer ${apiKey}`
             },
             responseType: 'stream'
@@ -1916,16 +1928,16 @@ function getExplanationCtx(cellUri: string) {
           for await (const chunk of resp.data) {
             chunkCount++;
             const lines = chunk.toString().split('\n');
-            
+
             for (const line of lines) {
               const trimmedLine = line.trim();
               if (!trimmedLine) continue;
-              
+
               try {
                 const jsonResponse = JSON.parse(trimmedLine);
                 if (jsonResponse.response) {
                   accumulated += jsonResponse.response;
-                  
+
                   const safeText = cleanMarkdown(accumulated);
                   const updatedContent = `${header}\n\n${safeText.replace(/\n/g, '  \n')}\n\n${generatingNote}`;
                   await replaceCellContent(doc, updatedContent);
@@ -1944,13 +1956,13 @@ function getExplanationCtx(cellUri: string) {
           const borderColor = mode === 'Expand' ? '#6ec5d2ff' : '#4CAF50';
           const wrappedContent = `<div style="box-sizing:border-box; border: 3px solid ${borderColor}; padding: 10px ;border-radius:8px;">\n\n${header}\n\n${finalText.replace(/\n/g, '  \n')}\n\n</div>`;
           const finalContent = `${wrappedContent}\n`;
-          await replaceCellContent(doc,finalContent);
+          await replaceCellContent(doc, finalContent);
 
           const cellUri = newCell.document.uri.toString();
           setExplanationCtx(cellUri, {
-            wholeFeedback: fullText,              
+            wholeFeedback: fullText,
           });
-        } catch (e:any) {
+        } catch (e: any) {
           console.error("AI Extension fail:", e);
           const errorMsg = `${header}\n\n❌ AI generation failed:\n\n\`${e.message}\``;
           await replaceCellContent(doc, errorMsg);
@@ -1968,7 +1980,7 @@ function getExplanationCtx(cellUri: string) {
       if (!editor) {
         return vscode.window.showErrorMessage('No active notebook editor');
       }
-      
+
       const cellUri = cell.document.uri.toString();
       const ctxData = getExplanationCtx?.(cellUri);
 
@@ -1977,7 +1989,7 @@ function getExplanationCtx(cellUri: string) {
       let followupPromptTpl = '';
       try {
         followupPromptTpl = await getPromptContent('followup');
-      } catch (e:any) {
+      } catch (e: any) {
         vscode.window.showErrorMessage('Failed to load Followup prompt: ' + e.message);
       }
       const panel = vscode.window.createWebviewPanel(
@@ -1989,7 +2001,7 @@ function getExplanationCtx(cellUri: string) {
 
 
       function getHTML() {
-      return `<!DOCTYPE html>
+        return `<!DOCTYPE html>
       <html lang="en">
       <head>
         <meta charset="UTF-8">
@@ -2259,7 +2271,7 @@ function getExplanationCtx(cellUri: string) {
         </script>
       </body>
       </html>`;
-        }
+      }
 
       panel.webview.html = getHTML();
 
@@ -2268,68 +2280,68 @@ function getExplanationCtx(cellUri: string) {
         //   const question = msg.question;
         //   conversation.push({ role: 'user', content: question });
 
-          if (msg.type !== 'ask') return;
+        if (msg.type !== 'ask') return;
 
-          const question = String(msg.question ?? '');
-          const wholeFeedback = ctxData?.wholeFeedback ?? '';
+        const question = String(msg.question ?? '');
+        const wholeFeedback = ctxData?.wholeFeedback ?? '';
 
-          // Concatenate prompt directly
-          const fullPrompt = followupPromptTpl
-            .replace('{{explanationOutput}}', explanationOutput)
-            .replace('{{wholeFeedback}}', wholeFeedback)
-            .replace('{{followupQuestion}}', question);
+        // Concatenate prompt directly
+        const fullPrompt = followupPromptTpl
+          .replace('{{explanationOutput}}', explanationOutput)
+          .replace('{{wholeFeedback}}', wholeFeedback)
+          .replace('{{followupQuestion}}', question);
 
-          const cfg = vscode.workspace.getConfiguration('CellMate');
-          const apiUrl = cfg.get<string>('apiUrl') || '';
-          const apiKey = cfg.get<string>('apiKey') || '';
-          const modelName = cfg.get<string>('modelName') || '';
+        const cfg = vscode.workspace.getConfiguration('CellMate');
+        const apiUrl = cfg.get<string>('apiUrl') || '';
+        const apiKey = cfg.get<string>('apiKey') || '';
+        const modelName = cfg.get<string>('modelName') || '';
 
-          try {
-          const resp = await axios.post(apiUrl, { model: modelName, prompt: fullPrompt, stream:false }, {
+        try {
+          const resp = await axios.post(apiUrl, { model: modelName, prompt: fullPrompt, stream: false }, {
             headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` }
           });
 
           const answer = resp.data?.message?.content || resp.data?.response || 'No response received';
           panel.webview.postMessage({ type: 'answer', content: answer });
-          } catch (e:any) {
-            panel.webview.postMessage({ type: 'answer', content: `❌ Request failed: ${e.message}` });
-          }
+        } catch (e: any) {
+          panel.webview.postMessage({ type: 'answer', content: `❌ Request failed: ${e.message}` });
+        }
       });
     })
   );
 
   ctx.subscriptions.push(
     vscode.notebooks.registerNotebookCellStatusBarItemProvider('jupyter-notebook', {
-    provideCellStatusBarItems(cell, _token) {
-      const items: vscode.NotebookCellStatusBarItem[] = [];
+      provideCellStatusBarItems(cell, _token) {
+        const items: vscode.NotebookCellStatusBarItem[] = [];
 
-      if (cell.kind === vscode.NotebookCellKind.Markup) {
-        const text = cell.document.getText();
+        if (cell.kind === vscode.NotebookCellKind.Markup) {
+          const text = cell.document.getText();
 
-        // Explanation cell
-        if (text.includes('**🤖Explanation** for:')) {
-          const item = new vscode.NotebookCellStatusBarItem(
-            '💬 Ask follow-up',
-            vscode.NotebookCellStatusBarAlignment.Right
-          );
-          item.command = 'CellMate.askFollowUpFromButton';
-          item.tooltip = 'Ask a follow-up question about this explanation';
-          items.push(item);
-        };
+          // Explanation cell
+          if (text.includes('**🤖Explanation** for:')) {
+            const item = new vscode.NotebookCellStatusBarItem(
+              '💬 Ask follow-up',
+              vscode.NotebookCellStatusBarAlignment.Right
+            );
+            item.command = 'CellMate.askFollowUpFromButton';
+            item.tooltip = 'Ask a follow-up question about this explanation';
+            items.push(item);
+          };
 
-        // Feeback Expansion cell
-        if (text.includes('**🤖Feedback Expansion**')){
-          const item = new vscode.NotebookCellStatusBarItem(
-            '💬 Ask follow-up',
-            vscode.NotebookCellStatusBarAlignment.Right
-          );
-          item.command = 'CellMate.askFollowUpFromButton';
-          item.tooltip = 'Ask a follow-up question about this explanation';
-          items.push(item);
+          // Feeback Expansion cell
+          if (text.includes('**🤖Feedback Expansion**')) {
+            const item = new vscode.NotebookCellStatusBarItem(
+              '💬 Ask follow-up',
+              vscode.NotebookCellStatusBarAlignment.Right
+            );
+            item.command = 'CellMate.askFollowUpFromButton';
+            item.tooltip = 'Ask a follow-up question about this explanation';
+            items.push(item);
+          }
         }
+        return items;
       }
-      return items;
-    }
     })
   );
 }


### PR DESCRIPTION
## Summary
This PR improves the user experience when requesting AI feedback without a valid exercise ID. 

Previously, users would either receive a generic warning (`No # EXERCISE_ID found in code`) without knowing what IDs were acceptable, or they would encounter an ugly, unhandled file system error (`ENOENT: no such file or directory`) if the ID was incorrect.

This update intercepts both scenarios and provides actionable feedback by querying the synced repository and displaying the list of all available exercise IDs.

## Changes Made
- Missing ID: Updated the warning message to dynamically include a comma-separated list of available IDs.
- Invalid ID: Wrapped `getTestFiles(exId)` in a `try-catch` block. If the directory doesn't exist, it now explicitly tells the user the exercise is "not found or invalid" and lists the available options.
- Formatting: Applied automated code formatting to `extension.ts` for improved readability and maintenance.

## How to Test
1. Open a Jupyter Notebook and create a code cell.
2. Click the AI Feedback button without adding an `# EXERCISE_ID`. Verify the warning shows a list of available IDs.
3. Add an invalid ID (e.g., `# EXERCISE_ID: wrong_id`) and click the button again. Verify the error popup gracefully states it's invalid and lists the available ones instead of a system crash log.