### PR TITLE
Part of implementation of light RAG

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,11 @@
             "default": true,
             "description": "Whether to use hidden tests to enhance the prompt with test analysis"
           },
+          "CellMate.useRAG": {
+            "type": "boolean",
+            "default": false,
+            "description": "Enable RAG to ground AI feedback in course materials from the knowledge/ directory in the promptfolio repository."
+          },
           "CellMate.errorHelperOutput": {
             "type": "string",
             "default": "markdown",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,8 +10,10 @@ import {
   getTestFiles,
   listLocalExercises,
   listLocalTemplates,
+  hasKnowledgeBase,
   LOCAL_REPO_PATH,
 } from './gitUtils';
+import { buildRagIndex, loadRagIndex, retrieveContext } from './ragUtils';
 import {
   getNotebookPythonPath,
   checkPytestInstalled,
@@ -1366,6 +1368,12 @@ ${feedback}
         // 1. Sync GitHub repository
         await syncGitRepo();
 
+        // Build RAG index if knowledge base exists and RAG is enabled
+        const useRAG = cfg.get<boolean>('useRAG', false);
+        if (useRAG && hasKnowledgeBase()) {
+          await buildRagIndex(LOCAL_REPO_PATH);
+        }
+
         // 2. Get prompt content
         const promptIdFromCell = extractPromptId(code);
         const promptId = promptIdFromCell || cfg.get<string>('templateId', '');
@@ -1517,6 +1525,21 @@ ${feedback}
           placeholderMap.set('hidden_tests', analysis);
         } else {
           placeholderMap.set('hidden_tests', '');
+        }
+
+        // RAG: retrieve relevant course materials if enabled
+        if (useRAG) {
+          const ragIndex = loadRagIndex();
+          if (ragIndex.length > 0) {
+            const ragQuery = code + '\n' + analysis;
+            const ragContext = retrieveContext(ragQuery, ragIndex, 3);
+            placeholderMap.set('rag_context', ragContext);
+            log('RAG context retrieved, chunks:', ragContext ? 'yes' : 'none');
+          } else {
+            placeholderMap.set('rag_context', '');
+          }
+        } else {
+          placeholderMap.set('rag_context', '');
         }
 
         // Fill only declared placeholders, keep others unchanged

--- a/src/gitUtils.ts
+++ b/src/gitUtils.ts
@@ -92,4 +92,11 @@ export async function listLocalTemplates(): Promise<any[]> {
       id: file.replace('.txt', ''), 
       filename: file 
     }));
-} 
+}
+
+/**
+ * Check if the synced repository contains a knowledge/ directory for RAG
+ */
+export function hasKnowledgeBase(): boolean {
+  return fs.existsSync(path.join(LOCAL_REPO_PATH, 'knowledge'));
+}

--- a/src/ragUtils.ts
+++ b/src/ragUtils.ts
@@ -1,0 +1,52 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import * as crypto from 'crypto';
+
+const RAG_CACHE_DIR = path.join(os.tmpdir(), 'cellmate_rag');
+const RAG_INDEX_FILE = path.join(RAG_CACHE_DIR, 'index.json');
+
+// English stopwords to filter out during tokenization
+const STOPWORDS = new Set([
+  'a', 'an', 'the', 'is', 'are', 'was', 'were', 'be', 'been', 'being',
+  'have', 'has', 'had', 'do', 'does', 'did', 'will', 'would', 'could',
+  'should', 'may', 'might', 'shall', 'can', 'need', 'dare', 'ought',
+  'used', 'to', 'of', 'in', 'for', 'on', 'with', 'at', 'by', 'from',
+  'as', 'into', 'through', 'during', 'before', 'after', 'above', 'below',
+  'between', 'out', 'off', 'over', 'under', 'again', 'further', 'then',
+  'once', 'here', 'there', 'when', 'where', 'why', 'how', 'all', 'each',
+  'every', 'both', 'few', 'more', 'most', 'other', 'some', 'such', 'no',
+  'nor', 'not', 'only', 'own', 'same', 'so', 'than', 'too', 'very',
+  'just', 'because', 'but', 'and', 'or', 'if', 'while', 'about', 'up',
+  'that', 'this', 'it', 'its', 'i', 'me', 'my', 'we', 'our', 'you',
+  'your', 'he', 'him', 'his', 'she', 'her', 'they', 'them', 'their',
+  'what', 'which', 'who', 'whom', 'these', 'those',
+]);
+
+/**
+ * A single chunk of knowledge content
+ */
+export interface RagChunk {
+  id: string;          // hash-based unique ID
+  source: string;      // relative path, e.g., "lectures/week2_loops.md"
+  title: string;       // heading or filename
+  content: string;     // chunk text
+  tokens: string[];    // lowercased, deduplicated keyword tokens
+}
+
+/**
+ * Tokenize text into lowercase keywords, filtering out stopwords and short tokens
+ */
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(/[^a-z0-9_]+/)
+    .filter(t => t.length > 1 && !STOPWORDS.has(t));
+}
+
+/**
+ * Generate a short hash ID for a chunk
+ */
+function hashId(source: string, title: string): string {
+  return crypto.createHash('md5').update(source + '::' + title).digest('hex').slice(0, 12);
+}


### PR DESCRIPTION
1. gitUtils.ts: Added hasKnowledgeBase() function that checks if knowledge/ exists in the synced repo
2. package.json: Added CellMate.useRAG setting (boolean, default false) — opt-in toggle
3. extension.ts: Three integration points:
- Imports — Added imports for hasKnowledgeBase, buildRagIndex, loadRagIndex, retrieveContext
- After syncGitRepo() — If RAG is enabled and knowledge/ exists, rebuilds the index
- Before prompt assembly — Retrieves top-3 relevant chunks and sets {{rag_context}} placeholder
4. New file: ragUtils.ts:
- Define STOPWORDS and a single chunk of knowledge content.
- Tokenize text into lowercase keywords, filtering out stopwords and short tokens.
- Generate a short hash ID for a chunk.