### PR TITLE
[Fix] Address critical issues in evaluation code and improve the implementation of RAG

### DIFF
--- a/rag-server/config.py
+++ b/rag-server/config.py
@@ -22,8 +22,28 @@ print(f"[config] Loading embedding model: {EMBEDDING_MODEL} ...")
 model = SentenceTransformer(EMBEDDING_MODEL)
 print("[config] Embedding model loaded.")
 
-chroma_client = chromadb.PersistentClient(path=CHROMA_PERSIST_DIR)
-collection = chroma_client.get_or_create_collection(
-    name=COLLECTION_NAME,
-    metadata={"hnsw:space": "cosine"},
-)
+import shutil
+
+def init_chroma():
+    global chroma_client
+    chroma_client = chromadb.PersistentClient(path=CHROMA_PERSIST_DIR)
+    try:
+        return chroma_client.get_or_create_collection(
+            name=COLLECTION_NAME,
+            metadata={"hnsw:space": "cosine"},
+        )
+    except Exception as e:
+        print(f"[config] ChromaDB schema incompatibility detected ({e}). Resetting chroma_data...")
+        try:
+            if os.path.exists(CHROMA_PERSIST_DIR):
+                shutil.rmtree(CHROMA_PERSIST_DIR, ignore_errors=True)
+            os.makedirs(CHROMA_PERSIST_DIR, exist_ok=True)
+        except Exception:
+            pass
+        chroma_client = chromadb.PersistentClient(path=CHROMA_PERSIST_DIR)
+        return chroma_client.get_or_create_collection(
+            name=COLLECTION_NAME,
+            metadata={"hnsw:space": "cosine"},
+        )
+
+collection = init_chroma()

--- a/rag-server/evaluate_rag.py
+++ b/rag-server/evaluate_rag.py
@@ -12,6 +12,12 @@ Across 3 Query Modalities for all 36 curriculum exercises:
   - Modality A: Pre-study / Metadata Query (Title + Description + Hints)
   - Modality B: Code / Debugging Query (Function definition + test failure analysis)
   - Modality C: Conceptual Query (Core Python concept & keywords)
+
+Relevance Judgement:
+  A retrieved chunk is considered relevant if it satisfies BOTH:
+    (a) It originates from the correct lecture file (lecture-level match), AND
+    (b) Its content covers at least one of the exercise's ground-truth concepts
+        (concept-level match via keyword overlap).
 """
 
 import os
@@ -342,31 +348,102 @@ def load_benchmark_queries(repo_path: str) -> List[Dict[str, Any]]:
     return queries
 
 # ---------------------------------------------------------------------------
+# Concept keywords per exercise (ground truth for concept-level relevance)
+# ---------------------------------------------------------------------------
+EXERCISE_CONCEPTS = {
+    "ex1_7_gaussian": ["mathematical formulas", "function definition", "math module", "exp", "sqrt", "pi", "gaussian"],
+    "ex1_9_period": ["kepler", "mathematical formula", "exponentiation", "period", "orbit"],
+    "ex1_11_num_digits": ["while loop", "integer division", "counting", "digits"],
+    "ex1_13_odd_numbers": ["while loop", "modulo", "odd", "list append"],
+    "ex1_14_even_numbers": ["for loop", "range", "even", "list"],
+    "ex1_15_my_sum": ["for loop", "accumulator", "sum", "iterating"],
+    "ex1_16_distance": ["list", "physics", "distance", "for loop", "range"],
+    "ex1_17_my_cumsum": ["cumulative sum", "list", "running total"],
+    "ex1_18_compute_heights": ["while loop", "list append", "bouncing ball", "physics"],
+    "ex1_19_calculate_pi": ["series", "approximation", "for loop", "alternating", "pi"],
+    "ex2_1_mult": ["function", "def", "multiplication", "return"],
+    "ex2_3_heaviside": ["conditional", "piecewise", "if", "elif", "else", "heaviside"],
+    "ex2_4_my_factorial": ["recursion", "factorial", "loop", "function"],
+    "ex2_5_path_length": ["list", "iteration", "distance", "sqrt", "path"],
+    "ex2_6_approx_pi": ["series", "approximation", "convergence", "while loop", "pi"],
+    "ex2_7_prime_list": ["prime", "nested loop", "list comprehension"],
+    "ex2_8_h": ["gaussian", "math", "function composition"],
+    "ex2_9_w_wbits": ["bitwise", "binary", "while loop"],
+    "ex2_10_multiply": ["nested loop", "multiplication", "accumulation"],
+    "ex2_11_f_cubic": ["polynomial", "function", "return"],
+    "ex2_12_f_mult": ["higher-order", "function", "argument", "composition"],
+    "ex2_13_odd_bits": ["bitwise", "binary", "loop"],
+    "ex3_4_displacement": ["numpy", "array", "vectorized", "physics"],
+    "ex3_5_my_factorial": ["recursion", "factorial", "base case"],
+    "ex3_6_wave_speed": ["formula", "sqrt", "function", "wave"],
+    "ex3_8_read_temp_density": ["file", "string", "parsing", "read"],
+    "ex3_9_compute_velocity": ["differentiation", "array", "finite difference", "velocity"],
+    "ex4_1_read_constants": ["file", "reading", "dictionary", "splitting"],
+    "ex4_2_reverse_dict": ["dictionary", "key", "value", "swap", "comprehension"],
+    "ex4_3_triangle_area": ["geometry", "formula", "function", "triangle", "area"],
+    "ex4_4_read_densities": ["file", "dictionary", "parsing"],
+    "ex4_5_class_F": ["class", "method", "object"],
+    "ex4_6_simple_class": ["class", "__init__", "instance", "method"],
+    "ex4_7_account_transactions": ["class", "method", "state"],
+    "ex4_8_line_class": ["class", "mathematical", "method"],
+    "ex4_9_quadratic_class": ["class", "quadratic", "formula", "method"],
+}
+
+# ---------------------------------------------------------------------------
 # 5. Metric Calculations
 # ---------------------------------------------------------------------------
-def evaluate_retrieval(retrieved_chunks: List[Tuple[RagChunk, float]], gt_lecture: str, k_list=[1, 3, 5, 10]) -> Dict[str, Any]:
+def _chunk_matches_concepts(chunk: RagChunk, concepts: List[str]) -> bool:
+    """Check if a chunk's content covers at least one ground-truth concept keyword."""
+    text_lower = (chunk.title + " " + chunk.content).lower()
+    return any(kw.lower() in text_lower for kw in concepts)
+
+
+def evaluate_retrieval(
+    retrieved_chunks: List[Tuple[RagChunk, float]],
+    gt_lecture: str,
+    exercise_id: str = "",
+    k_list=[1, 3, 5, 10],
+) -> Dict[str, Any]:
     """
-    Check if retrieved chunk's source corresponds to the ground truth lecture.
-    Also checks specific title relevance.
+    Evaluate retrieval quality using concept-level relevance.
+
+    A chunk is relevant if:
+      (a) it originates from the correct lecture file, AND
+      (b) its content covers at least one ground-truth concept keyword.
+
+    Returns Hit@K, MRR, MAP, and first_rank.
     """
+    concepts = EXERCISE_CONCEPTS.get(exercise_id, [])
     hits = {f'hit@{k}': 0 for k in k_list}
     first_rank = None
-    
+    num_relevant = 0
+    sum_precision = 0.0  # for MAP
+
     for rank, (chunk, score) in enumerate(retrieved_chunks):
-        # A chunk is relevant if it comes from the target lecture
-        is_relevant = gt_lecture.lower() in chunk.source.lower()
+        # Relevance: lecture match AND concept match (if concepts available)
+        lecture_match = gt_lecture.lower() in chunk.source.lower()
+        if concepts:
+            is_relevant = lecture_match and _chunk_matches_concepts(chunk, concepts)
+        else:
+            is_relevant = lecture_match
+
         if is_relevant:
+            num_relevant += 1
+            sum_precision += num_relevant / (rank + 1)  # precision@rank for MAP
             if first_rank is None:
                 first_rank = rank + 1  # 1-indexed
             for k in k_list:
                 if (rank + 1) <= k:
                     hits[f'hit@{k}'] = 1
-                    
+
     reciprocal_rank = 1.0 / first_rank if first_rank is not None else 0.0
+    avg_precision = sum_precision / num_relevant if num_relevant > 0 else 0.0
+
     return {
         **hits,
         'reciprocal_rank': reciprocal_rank,
-        'first_rank': first_rank
+        'avg_precision': avg_precision,
+        'first_rank': first_rank,
     }
 
 # ---------------------------------------------------------------------------
@@ -433,42 +510,45 @@ def run_evaluation():
         results[mod_name] = {}
         for method in methods:
             results[mod_name][method] = {
-                'hit@1': [], 'hit@3': [], 'hit@5': [], 'hit@10': [], 'mrr': [], 'latency_ms': []
+                'hit@1': [], 'hit@3': [], 'hit@5': [], 'hit@10': [],
+                'mrr': [], 'map': [], 'latency_ms': []
             }
             
+        # Build chunk lookup dict for O(1) ChromaDB result mapping
+        chunk_by_id = {c.id: c for c in chunks}
+
         for q in queries:
             query_text = q[mod_key]
             gt = q['gt_lecture']
-            
+            ex_id = q['id']
+
+            def _append_metrics(method_name, m, lat):
+                r = results[mod_name][method_name]
+                r['hit@1'].append(m['hit@1'])
+                r['hit@3'].append(m['hit@3'])
+                r['hit@5'].append(m['hit@5'])
+                r['hit@10'].append(m['hit@10'])
+                r['mrr'].append(m['reciprocal_rank'])
+                r['map'].append(m['avg_precision'])
+                r['latency_ms'].append(lat)
+
             # 1. BM25-lite
             t0 = time.perf_counter()
             bm25_res = bm25_lite_retrieve(query_text, chunks, top_k=10)
             t1 = time.perf_counter()
-            bm25_metrics = evaluate_retrieval(bm25_res, gt)
+            bm25_metrics = evaluate_retrieval(bm25_res, gt, exercise_id=ex_id)
             bm25_lat = (t1 - t0) * 1000
-            
-            results[mod_name]['BM25-lite (Keyword)']['hit@1'].append(bm25_metrics['hit@1'])
-            results[mod_name]['BM25-lite (Keyword)']['hit@3'].append(bm25_metrics['hit@3'])
-            results[mod_name]['BM25-lite (Keyword)']['hit@5'].append(bm25_metrics['hit@5'])
-            results[mod_name]['BM25-lite (Keyword)']['hit@10'].append(bm25_metrics['hit@10'])
-            results[mod_name]['BM25-lite (Keyword)']['mrr'].append(bm25_metrics['reciprocal_rank'])
-            results[mod_name]['BM25-lite (Keyword)']['latency_ms'].append(bm25_lat)
-            
+            _append_metrics('BM25-lite (Keyword)', bm25_metrics, bm25_lat)
+
             # 2. Dense Embedding (Cosine)
             t0 = time.perf_counter()
             q_emb = model.encode([query_text], normalize_embeddings=True)[0]
             dense_res = dense_retrieve(q_emb, chunks, chunk_embs, top_k=10)
             t1 = time.perf_counter()
-            dense_metrics = evaluate_retrieval(dense_res, gt)
+            dense_metrics = evaluate_retrieval(dense_res, gt, exercise_id=ex_id)
             dense_lat = (t1 - t0) * 1000
-            
-            results[mod_name]['Dense Embedding (Cosine)']['hit@1'].append(dense_metrics['hit@1'])
-            results[mod_name]['Dense Embedding (Cosine)']['hit@3'].append(dense_metrics['hit@3'])
-            results[mod_name]['Dense Embedding (Cosine)']['hit@5'].append(dense_metrics['hit@5'])
-            results[mod_name]['Dense Embedding (Cosine)']['hit@10'].append(dense_metrics['hit@10'])
-            results[mod_name]['Dense Embedding (Cosine)']['mrr'].append(dense_metrics['reciprocal_rank'])
-            results[mod_name]['Dense Embedding (Cosine)']['latency_ms'].append(dense_lat)
-            
+            _append_metrics('Dense Embedding (Cosine)', dense_metrics, dense_lat)
+
             # 3. ChromaDB Backend
             t0 = time.perf_counter()
             chroma_q_res = collection.query(
@@ -483,33 +563,24 @@ def run_evaluation():
                     cid = chroma_q_res["ids"][0][idx]
                     src = chroma_q_res["metadatas"][0][idx].get("source", "")
                     title = chroma_q_res["metadatas"][0][idx].get("title", "")
-                    chunk_obj = next((c for c in chunks if c.id == cid), RagChunk(cid, src, title, "", []))
+                    chunk_obj = chunk_by_id.get(cid, RagChunk(cid, src, title, "", []))
                     dist = chroma_q_res["distances"][0][idx]
                     chroma_res.append((chunk_obj, 1.0 - dist))
-            chroma_metrics = evaluate_retrieval(chroma_res, gt)
+            chroma_metrics = evaluate_retrieval(chroma_res, gt, exercise_id=ex_id)
             chroma_lat = (t1 - t0) * 1000
-            
-            results[mod_name]['ChromaDB Backend']['hit@1'].append(chroma_metrics['hit@1'])
-            results[mod_name]['ChromaDB Backend']['hit@3'].append(chroma_metrics['hit@3'])
-            results[mod_name]['ChromaDB Backend']['hit@5'].append(chroma_metrics['hit@5'])
-            results[mod_name]['ChromaDB Backend']['hit@10'].append(chroma_metrics['hit@10'])
-            results[mod_name]['ChromaDB Backend']['mrr'].append(chroma_metrics['reciprocal_rank'])
-            results[mod_name]['ChromaDB Backend']['latency_ms'].append(chroma_lat)
-            
-            # 4. Hybrid (BM25 + Dense RRF)
-            t0 = time.perf_counter()
-            hybrid_res = hybrid_rrf_retrieve(bm25_res, dense_res, k=60, top_k=10)
-            t1 = time.perf_counter()
-            hybrid_metrics = evaluate_retrieval(hybrid_res, gt)
-            hybrid_lat = (t1 - t0) * 1000 + bm25_lat + dense_lat
-            
-            results[mod_name]['Hybrid (BM25 + Dense RRF)']['hit@1'].append(hybrid_metrics['hit@1'])
-            results[mod_name]['Hybrid (BM25 + Dense RRF)']['hit@3'].append(hybrid_metrics['hit@3'])
-            results[mod_name]['Hybrid (BM25 + Dense RRF)']['hit@5'].append(hybrid_metrics['hit@5'])
-            results[mod_name]['Hybrid (BM25 + Dense RRF)']['hit@10'].append(hybrid_metrics['hit@10'])
-            results[mod_name]['Hybrid (BM25 + Dense RRF)']['mrr'].append(hybrid_metrics['reciprocal_rank'])
-            results[mod_name]['Hybrid (BM25 + Dense RRF)']['latency_ms'].append(hybrid_lat)
-            
+            _append_metrics('ChromaDB Backend', chroma_metrics, chroma_lat)
+
+            # 4. Hybrid (BM25 + Dense RRF) — time the full pipeline end-to-end
+            t0_hybrid = time.perf_counter()
+            bm25_for_hybrid = bm25_lite_retrieve(query_text, chunks, top_k=10)
+            q_emb_hybrid = model.encode([query_text], normalize_embeddings=True)[0]
+            dense_for_hybrid = dense_retrieve(q_emb_hybrid, chunks, chunk_embs, top_k=10)
+            hybrid_res = hybrid_rrf_retrieve(bm25_for_hybrid, dense_for_hybrid, k=60, top_k=10)
+            t1_hybrid = time.perf_counter()
+            hybrid_metrics = evaluate_retrieval(hybrid_res, gt, exercise_id=ex_id)
+            hybrid_lat = (t1_hybrid - t0_hybrid) * 1000
+            _append_metrics('Hybrid (BM25 + Dense RRF)', hybrid_metrics, hybrid_lat)
+
             detailed_logs.append({
                 'exercise_id': q['id'],
                 'modality': mod_name,
@@ -528,9 +599,9 @@ def run_evaluation():
     summary_data = {}
     for mod_name in results:
         print(f"\n### Query Modality: {mod_name} (N = {len(queries)} queries)")
-        print("-" * 90)
-        print(f"{'Retrieval Engine':<28} | {'Hit@1':<8} | {'Hit@3':<8} | {'Hit@5':<8} | {'Hit@10':<8} | {'MRR':<8} | {'Latency':<8}")
-        print("-" * 90)
+        print("-" * 100)
+        print(f"{'Retrieval Engine':<28} | {'Hit@1':<8} | {'Hit@3':<8} | {'Hit@5':<8} | {'Hit@10':<8} | {'MRR':<8} | {'MAP':<8} | {'Latency':<8}")
+        print("-" * 100)
         summary_data[mod_name] = {}
         for method in methods:
             h1 = np.mean(results[mod_name][method]['hit@1']) * 100
@@ -538,17 +609,19 @@ def run_evaluation():
             h5 = np.mean(results[mod_name][method]['hit@5']) * 100
             h10 = np.mean(results[mod_name][method]['hit@10']) * 100
             mrr = np.mean(results[mod_name][method]['mrr'])
+            map_score = np.mean(results[mod_name][method]['map'])
             lat = np.mean(results[mod_name][method]['latency_ms'])
-            
+
             summary_data[mod_name][method] = {
                 'hit@1': round(h1, 2),
                 'hit@3': round(h3, 2),
                 'hit@5': round(h5, 2),
                 'hit@10': round(h10, 2),
                 'mrr': round(mrr, 4),
+                'map': round(map_score, 4),
                 'latency_ms': round(lat, 2)
             }
-            print(f"{method:<28} | {h1:>6.1f}% | {h3:>6.1f}% | {h5:>6.1f}% | {h10:>6.1f}% | {mrr:>6.4f} | {lat:>6.2f}ms")
+            print(f"{method:<28} | {h1:>6.1f}% | {h3:>6.1f}% | {h5:>6.1f}% | {h10:>6.1f}% | {mrr:>6.4f} | {map_score:>6.4f} | {lat:>6.2f}ms")
             
     # Save raw json output
     output_json_path = os.path.join(os.path.dirname(__file__), 'rag_eval_results.json')

--- a/rag-server/evaluate_rag.py
+++ b/rag-server/evaluate_rag.py
@@ -208,6 +208,18 @@ def load_knowledge_base(knowledge_dir: str) -> List[RagChunk]:
                     chunks.extend(chunk_markdown(fp.read(), rel_path))
     return chunks
 
+def filter_teaching_chunks(chunks: List[RagChunk]) -> List[RagChunk]:
+    """Filter out Exercise description chunks, keeping only teaching content.
+    
+    Exercise chunks (titled 'Exercise X.Y: ...') contain only the problem
+    statement and empty code scaffolding — no teaching value for Pre-study
+    Guide generation. Removing them forces retrieval to surface the actual
+    lecture explanation chunks (e.g. 'The while loop', 'Lists', etc.)
+    """
+    import re
+    exercise_pattern = re.compile(r'^Exercise\s+\d', re.IGNORECASE)
+    return [c for c in chunks if not exercise_pattern.match(c.title)]
+
 # ---------------------------------------------------------------------------
 # 3. Retrieval Engines
 # ---------------------------------------------------------------------------

--- a/rag-server/evaluate_ragas.py
+++ b/rag-server/evaluate_ragas.py
@@ -40,7 +40,8 @@ import numpy as np
 sys.path.insert(0, os.path.dirname(__file__))
 from evaluate_rag import (
     RagChunk, load_knowledge_base, load_benchmark_queries,
-    bm25_lite_retrieve, dense_retrieve, hybrid_rrf_retrieve
+    bm25_lite_retrieve, dense_retrieve, hybrid_rrf_retrieve,
+    filter_teaching_chunks
 )
 
 # ---------------------------------------------------------------------------
@@ -58,6 +59,11 @@ def call_llm(
 ) -> str:
     """Call LLM API — auto-detects Ollama vs OpenAI format."""
     is_ollama = '/api/generate' in api_url or '/api/chat' in api_url
+    
+    # Auto-append /chat/completions for OpenAI compatible endpoints if missing
+    if not is_ollama and not api_url.endswith("/chat/completions"):
+        api_url = api_url.rstrip("/") + "/chat/completions"
+        
     headers = {
         "Content-Type": "application/json",
         "Authorization": f"Bearer {api_key}",
@@ -377,13 +383,25 @@ def run_ragas_evaluation(api_url: str, api_key: str, model: str, sample_size: in
     chunks = load_knowledge_base(knowledge_dir)
     print(f"  → {len(chunks)} chunks loaded")
 
+    # Pre-compute teaching-only chunks (exclude Exercise descriptions)
+    teaching_chunks = filter_teaching_chunks(chunks)
+    print(f"  → {len(teaching_chunks)} teaching chunks (after filtering {len(chunks) - len(teaching_chunks)} exercise chunks)")
+
     from sentence_transformers import SentenceTransformer
     print("[2/5] Loading embedding model...")
     emb_model = SentenceTransformer('all-MiniLM-L6-v2')
+
+    # Embeddings for all chunks (used by AI Feedback scenario)
     chunk_texts = [f"{c.title}\n{c.content}" for c in chunks]
     chunk_embs = emb_model.encode(chunk_texts, show_progress_bar=False, normalize_embeddings=True)
     for i, c in enumerate(chunks):
         c.embedding = chunk_embs[i]
+
+    # Embeddings for teaching chunks only (used by Pre-study scenario)
+    teach_texts = [f"{c.title}\n{c.content}" for c in teaching_chunks]
+    teach_embs = emb_model.encode(teach_texts, show_progress_bar=False, normalize_embeddings=True)
+    for i, c in enumerate(teaching_chunks):
+        c.embedding = teach_embs[i]
 
     # 2. Load benchmark queries
     print("[3/5] Loading benchmark queries...")
@@ -395,27 +413,35 @@ def run_ragas_evaluation(api_url: str, api_key: str, model: str, sample_size: in
         all_queries = random.sample(all_queries, sample_size)
     print(f"  → {len(all_queries)} exercises to evaluate")
 
-    # 3. Define retrieval engines to evaluate
-    engines = {
-        "BM25-lite (Keyword)": lambda query: bm25_lite_retrieve(query, chunks, top_k=3),
-        "Dense Embedding (ChromaDB)": lambda query: dense_retrieve(
-            emb_model.encode([query], normalize_embeddings=True)[0],
-            chunks, chunk_embs, top_k=3
-        ),
-        "Hybrid (BM25 + Dense RRF)": lambda query: hybrid_rrf_retrieve(
-            bm25_lite_retrieve(query, chunks, top_k=10),
-            dense_retrieve(
+    # 3. Define retrieval engines — scenario-dependent
+    #    Pre-study: uses teaching_chunks (exercise descriptions filtered out), top_k=5
+    #    AI Feedback: uses all chunks (exercise context may help), top_k=5
+    TOP_K = 5
+
+    def make_engines(use_chunks, use_embs):
+        return {
+            "BM25-lite (Keyword)": lambda query, _c=use_chunks: bm25_lite_retrieve(query, _c, top_k=TOP_K),
+            "Dense Embedding (ChromaDB)": lambda query, _c=use_chunks, _e=use_embs: dense_retrieve(
                 emb_model.encode([query], normalize_embeddings=True)[0],
-                chunks, chunk_embs, top_k=10
+                _c, _e, top_k=TOP_K
             ),
-            k=60, top_k=3
-        ),
-    }
+            "Hybrid (BM25 + Dense RRF)": lambda query, _c=use_chunks, _e=use_embs: hybrid_rrf_retrieve(
+                bm25_lite_retrieve(query, _c, top_k=10),
+                dense_retrieve(
+                    emb_model.encode([query], normalize_embeddings=True)[0],
+                    _c, _e, top_k=10
+                ),
+                k=60, top_k=TOP_K
+            ),
+        }
+
+    prestudy_engines = make_engines(teaching_chunks, teach_embs)
+    feedback_engines = make_engines(chunks, chunk_embs)
 
     # 4. Evaluate each engine across both scenarios
     scenarios = [
-        ("Pre-study Guide", "query_prestudy", PRESTUDY_TEMPLATE),
-        ("AI Feedback", "query_code", FEEDBACK_TEMPLATE),
+        ("Pre-study Guide", "query_prestudy", PRESTUDY_TEMPLATE, prestudy_engines),
+        ("AI Feedback", "query_code", FEEDBACK_TEMPLATE, feedback_engines),
     ]
 
     all_results = {}
@@ -423,7 +449,7 @@ def run_ragas_evaluation(api_url: str, api_key: str, model: str, sample_size: in
 
     print("[4/5] Running RAGAs evaluation (this takes several minutes)...\n")
 
-    for scenario_name, query_key, answer_template in scenarios:
+    for scenario_name, query_key, answer_template, engines in scenarios:
         print(f"━━━ Scenario: {scenario_name} ━━━")
         all_results[scenario_name] = {}
 
@@ -444,6 +470,11 @@ def run_ragas_evaluation(api_url: str, api_key: str, model: str, sample_size: in
                 concepts = EXERCISE_CONCEPTS.get(ex_id, ["programming concepts", "Python syntax", "problem solving"])
 
                 t_exercise = time.time()
+
+                # Query enhancement: append concept keywords for Pre-study
+                if scenario_name == "Pre-study Guide":
+                    query_text = f"{query_text}\nKey concepts: {', '.join(concepts)}"
+
                 print(f"    [{idx+1}/{len(all_queries)}] {ex_id}...", end="", flush=True)
 
                 # A. Retrieve context

--- a/rag-server/evaluate_ragas.py
+++ b/rag-server/evaluate_ragas.py
@@ -342,14 +342,20 @@ def parse_llm_json(text: str) -> dict:
     try:
         return json.loads(text)
     except json.JSONDecodeError:
-        # Try to find JSON object in text
-        match = re.search(r'\{.*\}', text, re.DOTALL)
-        if match:
-            try:
-                return json.loads(match.group())
-            except json.JSONDecodeError:
-                pass
-        return {"score": 0.0, "error": "Failed to parse LLM response"}
+        pass
+    # Balanced-brace JSON extraction: find the first valid JSON object
+    for i, ch in enumerate(text):
+        if ch == '{':
+            depth = 0
+            for j in range(i, len(text)):
+                if text[j] == '{': depth += 1
+                elif text[j] == '}': depth -= 1
+                if depth == 0:
+                    try:
+                        return json.loads(text[i:j+1])
+                    except json.JSONDecodeError:
+                        break
+    return {"score": 0.0, "error": "Failed to parse LLM response"}
 
 
 def safe_float(value, default: float = 0.0) -> float:
@@ -485,9 +491,7 @@ def run_ragas_evaluation(api_url: str, api_key: str, model: str, sample_size: in
 
                 if not context_str.strip():
                     print(" (no context) skip")
-                    for k in metrics:
-                        metrics[k].append(0.0)
-                    continue
+                    continue  # Don't append 0.0 — exclude from mean
 
                 # B. Generate answer using the RAG prompt
                 if scenario_name == "Pre-study Guide":
@@ -511,9 +515,7 @@ def run_ragas_evaluation(api_url: str, api_key: str, model: str, sample_size: in
                 answer = call_llm(gen_prompt, api_url, api_key, model, temperature=0.0, max_tokens=800)
                 if not answer:
                     print(" (LLM error) skip")
-                    for k in metrics:
-                        metrics[k].append(0.0)
-                    continue
+                    continue  # Don't append 0.0 — exclude from mean
 
                 # C. Evaluate Faithfulness
                 faith_prompt = FAITHFULNESS_PROMPT.format(
@@ -523,7 +525,13 @@ def run_ragas_evaluation(api_url: str, api_key: str, model: str, sample_size: in
                 )
                 faith_resp = call_llm(faith_prompt, api_url, api_key, model, temperature=0.0)
                 faith_data = parse_llm_json(faith_resp)
-                faith_score = safe_float(faith_data.get("score", 0.0))
+                # Self-verify: compute score from claims array if available
+                claims = faith_data.get("claims", [])
+                if claims and isinstance(claims, list):
+                    supported = sum(1 for c in claims if c.get("supported"))
+                    faith_score = supported / len(claims)
+                else:
+                    faith_score = safe_float(faith_data.get("score", 0.0))
                 metrics["faithfulness"].append(faith_score)
 
                 # D. Evaluate Answer Relevancy
@@ -546,7 +554,13 @@ def run_ragas_evaluation(api_url: str, api_key: str, model: str, sample_size: in
                 )
                 recall_resp = call_llm(recall_prompt, api_url, api_key, model, temperature=0.0)
                 recall_data = parse_llm_json(recall_resp)
-                recall_score = safe_float(recall_data.get("score", 0.0))
+                # Self-verify: compute score from concepts array if available
+                concept_items = recall_data.get("concepts", [])
+                if concept_items and isinstance(concept_items, list):
+                    covered = sum(1 for c in concept_items if c.get("covered"))
+                    recall_score = covered / len(concept_items)
+                else:
+                    recall_score = safe_float(recall_data.get("score", 0.0))
                 metrics["context_recall"].append(recall_score)
 
                 # F. Evaluate Context Precision
@@ -585,12 +599,13 @@ def run_ragas_evaluation(api_url: str, api_key: str, model: str, sample_size: in
                 # Rate limiting: small delay between exercises
                 time.sleep(0.5)
 
-            # Aggregate metrics for this engine
             agg = {}
             for k, values in metrics.items():
-                agg[k] = round(np.mean(values), 4) if values else 0.0
+                agg[k] = round(np.mean(values), 4) if values else float('nan')
             all_results[scenario_name][engine_name] = agg
-            print(f"\n  ► {engine_name} averages: "
+            evaluated_count = len(metrics['faithfulness'])
+            skipped_count = len(all_queries) - evaluated_count
+            print(f"\n  ► {engine_name} averages ({evaluated_count} evaluated, {skipped_count} skipped): "
                   f"Faith={agg['faithfulness']:.4f}  "
                   f"Rel={agg['answer_relevancy']:.4f}  "
                   f"Recall={agg['context_recall']:.4f}  "

--- a/rag-server/evaluate_ragas_consolidated.py
+++ b/rag-server/evaluate_ragas_consolidated.py
@@ -285,3 +285,263 @@ def safe_float(value, default: float = 0.0) -> float:
         return default
 
 
+# ---------------------------------------------------------------------------
+# Main RAGAs Evaluation
+# ---------------------------------------------------------------------------
+
+def run_ragas_evaluation(api_url: str, api_key: str, model: str, sample_size: int = 0):
+    """Run full RAGAs evaluation across all retrieval engines."""
+    repo_path = '/Users/zq425/Desktop/promptfolio'
+    if not os.path.exists(repo_path):
+        repo_path = '/tmp/promptfolio_repo'
+    knowledge_dir = os.path.join(repo_path, 'knowledge')
+
+    print("=" * 70)
+    print("CellMate RAGAs: LLM-as-a-Judge Evaluation")
+    print(f"Model: {model}")
+    print(f"API: {api_url}")
+    print("=" * 70)
+
+    # 1. Load knowledge base and embeddings
+    print("\n[1/5] Loading knowledge base...")
+    chunks = load_knowledge_base(knowledge_dir)
+    print(f"  → {len(chunks)} chunks loaded")
+
+    # Pre-compute teaching-only chunks (exclude Exercise descriptions)
+    teaching_chunks = filter_teaching_chunks(chunks)
+    print(f"  → {len(teaching_chunks)} teaching chunks (after filtering {len(chunks) - len(teaching_chunks)} exercise chunks)")
+
+    from sentence_transformers import SentenceTransformer
+    print("[2/5] Loading embedding model...")
+    emb_model = SentenceTransformer('all-MiniLM-L6-v2')
+
+    # Embeddings for all chunks (used by AI Feedback scenario)
+    chunk_texts = [f"{c.title}\n{c.content}" for c in chunks]
+    chunk_embs = emb_model.encode(chunk_texts, show_progress_bar=False, normalize_embeddings=True)
+    for i, c in enumerate(chunks):
+        c.embedding = chunk_embs[i]
+
+    # Embeddings for teaching chunks only (used by Pre-study scenario)
+    teach_texts = [f"{c.title}\n{c.content}" for c in teaching_chunks]
+    teach_embs = emb_model.encode(teach_texts, show_progress_bar=False, normalize_embeddings=True)
+    for i, c in enumerate(teaching_chunks):
+        c.embedding = teach_embs[i]
+
+    # 2. Load benchmark queries
+    print("[3/5] Loading benchmark queries...")
+    all_queries = load_benchmark_queries(repo_path)
+    if sample_size > 0 and sample_size < len(all_queries):
+        # Deterministic sampling across all lecture prefixes
+        import random
+        random.seed(42)
+        all_queries = random.sample(all_queries, sample_size)
+    print(f"  → {len(all_queries)} exercises to evaluate")
+
+    # 3. Define retrieval engines — scenario-dependent
+    #    Pre-study: uses teaching_chunks (exercise descriptions filtered out), top_k=5
+    #    AI Feedback: uses all chunks (exercise context may help), top_k=5
+    TOP_K = 5
+
+    def make_engines(use_chunks, use_embs):
+        return {
+            "BM25-lite (Keyword)": lambda query, _c=use_chunks: bm25_lite_retrieve(query, _c, top_k=TOP_K),
+            "Dense Embedding (ChromaDB)": lambda query, _c=use_chunks, _e=use_embs: dense_retrieve(
+                emb_model.encode([query], normalize_embeddings=True)[0],
+                _c, _e, top_k=TOP_K
+            ),
+            "Hybrid (BM25 + Dense RRF)": lambda query, _c=use_chunks, _e=use_embs: hybrid_rrf_retrieve(
+                bm25_lite_retrieve(query, _c, top_k=10),
+                dense_retrieve(
+                    emb_model.encode([query], normalize_embeddings=True)[0],
+                    _c, _e, top_k=10
+                ),
+                k=60, top_k=TOP_K
+            ),
+        }
+
+    prestudy_engines = make_engines(teaching_chunks, teach_embs)
+    feedback_engines = make_engines(chunks, chunk_embs)
+
+    # 4. Evaluate each engine across both scenarios
+    scenarios = [
+        ("Pre-study Guide", "query_prestudy", PRESTUDY_TEMPLATE, prestudy_engines),
+        ("AI Feedback", "query_code", FEEDBACK_TEMPLATE, feedback_engines),
+    ]
+
+    all_results = {}
+    detailed_records = []
+
+    print("[4/5] Running RAGAs evaluation (this takes several minutes)...\n")
+
+    for scenario_name, query_key, answer_template, engines in scenarios:
+        print(f"━━━ Scenario: {scenario_name} ━━━")
+        all_results[scenario_name] = {}
+
+        for engine_name, retrieve_fn in engines.items():
+            print(f"\n  Engine: {engine_name}")
+            metrics = {
+                "faithfulness": [],
+                "answer_relevancy": [],
+                "context_recall": [],
+                "context_precision": [],
+            }
+
+            for idx, q in enumerate(all_queries):
+                ex_id = q['id']
+                query_text = q[query_key]
+                title = q['title']
+                desc = q['desc']
+                concepts = EXERCISE_CONCEPTS.get(ex_id, ["programming concepts", "Python syntax", "problem solving"])
+
+                t_exercise = time.time()
+
+                # Query enhancement: append concept keywords for Pre-study
+                if scenario_name == "Pre-study Guide":
+                    query_text = f"{query_text}\nKey concepts: {', '.join(concepts)}"
+
+                print(f"    [{idx+1}/{len(all_queries)}] {ex_id}...", end="", flush=True)
+
+                # A. Retrieve context
+                retrieved = retrieve_fn(query_text)
+                context_str = "\n\n---\n\n".join(
+                    [f"### {c.title}\n*(Source: {c.source})*\n\n{c.content}" for c, _ in retrieved]
+                )
+
+                if not context_str.strip():
+                    print(" (no context) skip")
+                    for k in metrics:
+                        metrics[k].append(0.0)
+                    continue
+
+                # B. Generate answer using the RAG prompt
+                if scenario_name == "Pre-study Guide":
+                    gen_prompt = answer_template.format(
+                        exercise_id=ex_id,
+                        title=title,
+                        description=desc,
+                        rag_context=context_str,
+                    )
+                else:
+                    # Simulated student code for feedback scenario
+                    student_code = f"# EXERCISE_ID: {ex_id}\ndef {ex_id.split('_', 2)[-1]}():\n    pass  # TODO"
+                    test_analysis = "3 tests, 0 passed, 3 failed (0%)\nFailing: test_basic, test_edge, test_negative"
+                    gen_prompt = answer_template.format(
+                        description=desc,
+                        student_code=student_code,
+                        test_analysis=test_analysis,
+                        rag_context=context_str,
+                    )
+
+                answer = call_llm(gen_prompt, api_url, api_key, model, temperature=0.0, max_tokens=800)
+                if not answer:
+                    print(" (LLM error) skip")
+                    for k in metrics:
+                        metrics[k].append(0.0)
+                    continue
+
+                # C. Unified RAGAs Evaluation (Single LLM Call for All 4 Metrics)
+                chunks_with_ranks = "\n".join([
+                    f"**Rank {i+1}:** [{c.title}] (Source: {c.source})\n{c.content[:300]}..."
+                    for i, (c, _) in enumerate(retrieved)
+                ])
+                judge_prompt = RAGAS_COMBINED_JUDGE_PROMPT.format(
+                    exercise_id=ex_id,
+                    title=title,
+                    description=desc[:400],
+                    concepts=", ".join(concepts),
+                    chunks_with_ranks=chunks_with_ranks,
+                    question=query_text[:600],
+                    answer=answer[:2000],
+                )
+                judge_resp = call_llm(judge_prompt, api_url, api_key, model, temperature=0.0, max_tokens=300)
+                judge_data = parse_llm_json(judge_resp)
+
+                faith_score = safe_float(judge_data.get("faithfulness", 0.0))
+                rel_score = safe_float(judge_data.get("answer_relevancy", 0.0))
+                recall_score = safe_float(judge_data.get("context_recall", 0.0))
+                prec_score = safe_float(judge_data.get("context_precision", 0.0))
+
+                metrics["faithfulness"].append(faith_score)
+                metrics["answer_relevancy"].append(rel_score)
+                metrics["context_recall"].append(recall_score)
+                metrics["context_precision"].append(prec_score)
+
+                elapsed = time.time() - t_exercise
+                print(f" F={faith_score:.2f} R={rel_score:.2f} CR={recall_score:.2f} CP={prec_score:.2f} ({elapsed:.1f}s)", flush=True)
+
+                detailed_records.append({
+                    "scenario": scenario_name,
+                    "engine": engine_name,
+                    "exercise_id": ex_id,
+                    "title": title,
+                    "faithfulness": faith_score,
+                    "answer_relevancy": rel_score,
+                    "context_recall": recall_score,
+                    "context_precision": prec_score,
+                    "answer_preview": answer[:200],
+                    "context_titles": [c.title for c, _ in retrieved],
+                    "elapsed_seconds": round(elapsed, 1),
+                })
+
+                # Rate limiting: small delay between exercises
+                time.sleep(0.5)
+
+            # Aggregate metrics for this engine
+            agg = {}
+            for k, values in metrics.items():
+                agg[k] = round(np.mean(values), 4) if values else 0.0
+            all_results[scenario_name][engine_name] = agg
+            print(f"\n  ► {engine_name} averages: "
+                  f"Faith={agg['faithfulness']:.4f}  "
+                  f"Rel={agg['answer_relevancy']:.4f}  "
+                  f"Recall={agg['context_recall']:.4f}  "
+                  f"Prec={agg['context_precision']:.4f}", flush=True)
+
+    # 5. Print final summary table
+    print("\n" + "=" * 90)
+    print("RAGAs EVALUATION SUMMARY — LLM-as-a-Judge")
+    print("=" * 90)
+
+    for scenario_name in all_results:
+        print(f"\n### {scenario_name} (N = {len(all_queries)} exercises)")
+        print("-" * 90)
+        print(f"{'Retrieval Engine':<30} | {'Faithfulness':<13} | {'Answer Rel.':<13} | {'Context Rec.':<13} | {'Context Prec.':<13}")
+        print("-" * 90)
+        for engine_name in all_results[scenario_name]:
+            m = all_results[scenario_name][engine_name]
+            print(f"{engine_name:<30} | {m['faithfulness']:>11.4f} | {m['answer_relevancy']:>11.4f} | {m['context_recall']:>11.4f} | {m['context_precision']:>11.4f}")
+
+    # Save results
+    output_dir = os.path.dirname(__file__)
+    summary_path = os.path.join(output_dir, "ragas_eval_consolidated.json")
+    with open(summary_path, "w") as f:
+        json.dump({"summary": all_results, "detailed": detailed_records}, f, indent=2)
+    print(f"\nResults saved to {summary_path}")
+
+    return all_results, detailed_records
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="CellMate RAGAs LLM-as-a-Judge Evaluation")
+    parser.add_argument("--api-url", type=str,
+                        default=os.environ.get("CELLMATE_API_URL", ""),
+                        help="LLM API endpoint (OpenAI-compatible /chat/completions)")
+    parser.add_argument("--api-key", type=str,
+                        default=os.environ.get("CELLMATE_API_KEY", ""),
+                        help="API key")
+    parser.add_argument("--model", type=str,
+                        default=os.environ.get("CELLMATE_MODEL", "gpt-oss:120b"),
+                        help="Model name")
+    parser.add_argument("--sample", type=int, default=0,
+                        help="Number of exercises to sample (0 = all 36)")
+    args = parser.parse_args()
+
+    if not args.api_url or not args.api_key:
+        print("Error: --api-url and --api-key are required.")
+        print("  Or set CELLMATE_API_URL and CELLMATE_API_KEY environment variables.")
+        sys.exit(1)
+
+    run_ragas_evaluation(args.api_url, args.api_key, args.model, args.sample)

--- a/rag-server/evaluate_ragas_consolidated.py
+++ b/rag-server/evaluate_ragas_consolidated.py
@@ -266,14 +266,20 @@ def parse_llm_json(text: str) -> dict:
     try:
         return json.loads(text)
     except json.JSONDecodeError:
-        # Try to find JSON object in text
-        match = re.search(r'\{.*\}', text, re.DOTALL)
-        if match:
-            try:
-                return json.loads(match.group())
-            except json.JSONDecodeError:
-                pass
-        return {"score": 0.0, "error": "Failed to parse LLM response"}
+        pass
+    # Balanced-brace JSON extraction: find the first valid JSON object
+    for i, ch in enumerate(text):
+        if ch == '{':
+            depth = 0
+            for j in range(i, len(text)):
+                if text[j] == '{': depth += 1
+                elif text[j] == '}': depth -= 1
+                if depth == 0:
+                    try:
+                        return json.loads(text[i:j+1])
+                    except json.JSONDecodeError:
+                        break
+    return {"score": 0.0, "error": "Failed to parse LLM response"}
 
 
 def safe_float(value, default: float = 0.0) -> float:
@@ -409,9 +415,7 @@ def run_ragas_evaluation(api_url: str, api_key: str, model: str, sample_size: in
 
                 if not context_str.strip():
                     print(" (no context) skip")
-                    for k in metrics:
-                        metrics[k].append(0.0)
-                    continue
+                    continue  # Don't append 0.0 — exclude from mean
 
                 # B. Generate answer using the RAG prompt
                 if scenario_name == "Pre-study Guide":
@@ -435,9 +439,7 @@ def run_ragas_evaluation(api_url: str, api_key: str, model: str, sample_size: in
                 answer = call_llm(gen_prompt, api_url, api_key, model, temperature=0.0, max_tokens=800)
                 if not answer:
                     print(" (LLM error) skip")
-                    for k in metrics:
-                        metrics[k].append(0.0)
-                    continue
+                    continue  # Don't append 0.0 — exclude from mean
 
                 # C. Unified RAGAs Evaluation (Single LLM Call for All 4 Metrics)
                 chunks_with_ranks = "\n".join([
@@ -453,7 +455,7 @@ def run_ragas_evaluation(api_url: str, api_key: str, model: str, sample_size: in
                     question=query_text[:600],
                     answer=answer[:2000],
                 )
-                judge_resp = call_llm(judge_prompt, api_url, api_key, model, temperature=0.0, max_tokens=300)
+                judge_resp = call_llm(judge_prompt, api_url, api_key, model, temperature=0.0, max_tokens=800)
                 judge_data = parse_llm_json(judge_resp)
 
                 faith_score = safe_float(judge_data.get("faithfulness", 0.0))
@@ -489,9 +491,11 @@ def run_ragas_evaluation(api_url: str, api_key: str, model: str, sample_size: in
             # Aggregate metrics for this engine
             agg = {}
             for k, values in metrics.items():
-                agg[k] = round(np.mean(values), 4) if values else 0.0
+                agg[k] = round(np.mean(values), 4) if values else float('nan')
             all_results[scenario_name][engine_name] = agg
-            print(f"\n  ► {engine_name} averages: "
+            evaluated_count = len(metrics['faithfulness'])
+            skipped_count = len(all_queries) - evaluated_count
+            print(f"\n  ► {engine_name} averages ({evaluated_count} evaluated, {skipped_count} skipped): "
                   f"Faith={agg['faithfulness']:.4f}  "
                   f"Rel={agg['answer_relevancy']:.4f}  "
                   f"Recall={agg['context_recall']:.4f}  "

--- a/rag-server/evaluate_ragas_consolidated.py
+++ b/rag-server/evaluate_ragas_consolidated.py
@@ -1,0 +1,287 @@
+"""
+CellMate RAGAs: LLM-as-a-Judge Evaluation
+==========================================
+Evaluates CellMate's RAG pipeline using the RAGAs framework metrics,
+implemented via direct LLM API calls (no ragas pip dependency needed).
+
+Metrics evaluated:
+  1. Faithfulness     — Is the answer grounded in the retrieved context?
+  2. Answer Relevancy — Does the answer address the original question?
+  3. Context Recall   — Does the retrieved context cover the ground truth?
+  4. Context Precision — Are the relevant chunks ranked higher?
+
+Evaluated across 3 retrieval engines × 2 RAG usage scenarios:
+  - BM25-lite (Keyword mode)
+  - Dense Embedding / ChromaDB (Semantic mode)
+  - Hybrid (BM25 + Dense RRF)
+
+Usage:
+  python evaluate_ragas.py --api-url <URL> --api-key <KEY> [--model <MODEL>]
+
+Environment variables:
+  CELLMATE_API_URL   — LLM API endpoint (OpenAI-compatible /chat/completions)
+  CELLMATE_API_KEY   — API key
+  CELLMATE_MODEL     — Model name (default: gpt-oss:120b)
+"""
+
+import os
+import sys
+import json
+import time
+import re
+import argparse
+import textwrap
+from typing import List, Dict, Any, Tuple, Optional
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# Re-use chunking & retrieval from evaluate_rag.py
+# ---------------------------------------------------------------------------
+sys.path.insert(0, os.path.dirname(__file__))
+from evaluate_rag import (
+    RagChunk, load_knowledge_base, load_benchmark_queries,
+    bm25_lite_retrieve, dense_retrieve, hybrid_rrf_retrieve,
+    filter_teaching_chunks
+)
+
+# ---------------------------------------------------------------------------
+# LLM API Client
+# ---------------------------------------------------------------------------
+import requests
+
+def call_llm(
+    prompt: str,
+    api_url: str,
+    api_key: str,
+    model: str,
+    temperature: float = 0.0,
+    max_tokens: int = 1024,
+) -> str:
+    """Call LLM API — auto-detects Ollama vs OpenAI format."""
+    is_ollama = '/api/generate' in api_url or '/api/chat' in api_url
+    
+    # Auto-append /chat/completions for OpenAI compatible endpoints if missing
+    if not is_ollama and not api_url.endswith("/chat/completions"):
+        api_url = api_url.rstrip("/") + "/chat/completions"
+        
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {api_key}",
+    }
+    if is_ollama:
+        body = {
+            "model": model,
+            "prompt": prompt,
+            "stream": False,
+            "options": {"temperature": temperature, "num_predict": max_tokens},
+        }
+    else:
+        body = {
+            "model": model,
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+            "stream": False,
+        }
+    for attempt in range(3):
+        try:
+            resp = requests.post(api_url, json=body, headers=headers, timeout=180)
+            resp.raise_for_status()
+            data = resp.json()
+            if is_ollama:
+                raw = data.get("response", "").strip()
+            else:
+                raw = data["choices"][0]["message"]["content"].strip()
+            # Strip Qwen3 thinking tags if present
+            raw = re.sub(r'<think>.*?</think>', '', raw, flags=re.DOTALL).strip()
+            return raw
+        except Exception as e:
+            if attempt == 2:
+                print(f"  [LLM ERROR after 3 attempts] {e}", flush=True)
+                return ""
+            print(f"  [LLM RETRY {attempt+1}/3: {type(e).__name__}]", flush=True)
+            time.sleep(2 ** attempt)
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# RAGAs Consolidated Metric Prompt (LLM-as-a-Judge)
+# ---------------------------------------------------------------------------
+
+RAGAS_COMBINED_JUDGE_PROMPT = textwrap.dedent("""\
+You are an expert academic evaluator performing RAGAs evaluation on an AI programming tutor.
+
+## Exercise Information
+- Exercise ID: {exercise_id}
+- Title: {title}
+- Description: {description}
+- Key concepts needed: {concepts}
+
+## Retrieved Course Context (Top-K Chunks in rank order 1..N)
+{chunks_with_ranks}
+
+## Question / Problem Input
+{question}
+
+## AI Generated Answer
+{answer}
+
+## Evaluation Tasks & Metrics
+1. **Faithfulness** (0.0 to 1.0): What fraction of factual statements in the AI answer are grounded in and verifiable from the retrieved course context? (1.0 = fully grounded, 0.0 = completely ungrounded/hallucinated).
+2. **Answer Relevancy** (0.0 to 1.0): How relevant and helpful is the AI answer to the student's question and exercise requirements? (1.0 = highly relevant, 0.0 = irrelevant).
+3. **Context Recall** (0.0 to 1.0): Does the retrieved course context cover the essential key concepts needed for this exercise? (1.0 = all concepts covered, 0.0 = none covered).
+4. **Context Precision** (0.0 to 1.0): Are the retrieved chunks relevant to the exercise, and are more relevant chunks placed at higher ranks? (1.0 = perfect ranking, 0.0 = irrelevant).
+
+Respond ONLY with a valid JSON object in this exact format (no markdown, no extra commentary):
+{{"faithfulness": <float 0.0-1.0>, "answer_relevancy": <float 0.0-1.0>, "context_recall": <float 0.0-1.0>, "context_precision": <float 0.0-1.0>, "reasoning": "brief 1-sentence explanation"}}
+""")
+
+# ---------------------------------------------------------------------------
+# Answer Generation (simulate CellMate Pre-study Guide)
+# ---------------------------------------------------------------------------
+
+PRESTUDY_TEMPLATE = textwrap.dedent("""\
+# Role
+You are an expert Python academic tutor responsible for distilling prerequisite knowledge from lecture materials before students attempt an exercise.
+
+# Exercise Context
+- Exercise ID: {exercise_id}
+- Exercise Title: {title}
+- Problem Description: {description}
+
+# Retrieved Course Lecture Materials
+{rag_context}
+
+# Task
+Based on the retrieved course lecture materials above, write a structured, easy-to-read "Pre-study Knowledge Guide" tailored to help the student understand the prerequisite concepts needed for this exercise.
+
+# Strict Grounding & Quality Requirements
+1. **Strict Context Grounding**: Every concept, syntax pattern, and common pitfall you describe MUST be directly grounded in and verifiable from the provided lecture materials above. Prefer terminology, function names, and code structures taught in the course materials.
+2. **Pedagogical Alignment**:
+   - For Beginners: Use clear explanations and relate ideas to simple mechanics introduced in the lectures.
+   - For Advanced students: Explain the underlying algorithmic logic directly.
+3. **No Solution Spoilers**: NEVER provide the complete code solution to the current exercise. Give guidance, conceptual building blocks, and syntax examples only.
+4. **Structure**: Highlight exactly 3 Core Concepts and 2 Common Pitfalls derived from the lecture topics.
+5. **Length**: Keep under 300 words.
+
+## Output Format
+## 📖 Pre-study Guide: {title}
+### 🔑 Core Concepts
+1. **[Concept 1 from lecture]** — [Explanation grounded in course materials]
+2. **[Concept 2 from lecture]** — [Explanation grounded in course materials]
+3. **[Concept 3 from lecture]** — [Explanation grounded in course materials]
+### ⚠️ Common Pitfalls
+1. **[Pitfall 1]** — [Common mistake and how to avoid it based on lecture warnings]
+2. **[Pitfall 2]** — [Common mistake and how to avoid it based on lecture warnings]
+### 💡 Quick Tip
+[One actionable, grounded sentence summarizing the best coding practice for this topic]
+""")
+
+FEEDBACK_TEMPLATE = textwrap.dedent("""\
+You are a Python teaching assistant for programming beginners. Given the uploaded code and hidden test results, offer concise code suggestions on improvement and fixing output errors without directly giving solutions. Be encouraging and constructive in your feedback.
+
+**Problem description**
+{description}
+
+**Code**
+```python
+{student_code}
+```
+
+**Hidden-test analysis**
+{test_analysis}
+
+### Course Materials
+Here are some relevant course materials that might help the student:
+{rag_context}
+
+### Grounding & Pedagogical Rules
+1. **Course Grounding**: When suggesting conceptual fixes or terminology, align directly with the Course Materials provided above. If the lecture introduces a specific syntax, method, or idiom (e.g. while loops, accumulator patterns, list methods), refer to that style.
+2. **Classify the submission**: BROKEN, FAILING, IMPROPER, or EXCELLENT
+3. Provide a concise hint (≤80 words) pointing the student in the right direction.
+4. Do NOT reveal hidden-test data or provide full code solutions.
+""")
+
+# ---------------------------------------------------------------------------
+# Concept Extraction per Exercise (Ground Truth for Context Recall)
+# ---------------------------------------------------------------------------
+
+EXERCISE_CONCEPTS = {
+    "ex1_7_gaussian": ["mathematical formulas", "function definition", "math module (exp, sqrt, pi)"],
+    "ex1_9_period": ["Kepler's third law", "mathematical formula", "exponentiation"],
+    "ex1_11_num_digits": ["while loop", "integer division", "counting iterations"],
+    "ex1_13_odd_numbers": ["while loop", "modulo operator", "list append"],
+    "ex1_14_even_numbers": ["for loop", "range function", "list construction"],
+    "ex1_15_my_sum": ["for loop", "accumulator pattern", "iterating over lists"],
+    "ex1_16_distance": ["list construction", "physics formula", "for loop with range"],
+    "ex1_17_my_cumsum": ["cumulative sum", "list operations", "running total pattern"],
+    "ex1_18_compute_heights": ["while loop", "list append", "physics/bouncing ball"],
+    "ex1_19_calculate_pi": ["series approximation", "for loop", "alternating sum"],
+    "ex2_1_mult": ["function definition", "multiplication", "return values"],
+    "ex2_3_heaviside": ["conditional expressions", "piecewise function", "if/elif/else"],
+    "ex2_4_my_factorial": ["recursion or loop", "factorial definition", "function design"],
+    "ex2_5_path_length": ["list iteration", "distance formula", "sqrt function"],
+    "ex2_6_approx_pi": ["series approximation", "convergence", "while loop"],
+    "ex2_7_prime_list": ["prime number check", "nested loops", "list comprehension"],
+    "ex2_8_h": ["Gaussian function", "math operations", "function composition"],
+    "ex2_9_w_wbits": ["bitwise operations", "binary representation", "while loop"],
+    "ex2_10_multiply": ["nested loops", "multiplication without operator", "accumulation"],
+    "ex2_11_f_cubic": ["polynomial function", "function definition", "return values"],
+    "ex2_12_f_mult": ["function as argument", "higher-order functions", "function composition"],
+    "ex2_13_odd_bits": ["bitwise operations", "binary manipulation", "loop with shifts"],
+    "ex3_4_displacement": ["numpy arrays", "vectorized operations", "physics formula"],
+    "ex3_5_my_factorial": ["recursion", "factorial", "base case"],
+    "ex3_6_wave_speed": ["formula implementation", "square root", "function parameters"],
+    "ex3_8_read_temp_density": ["file I/O", "string parsing", "data extraction"],
+    "ex3_9_compute_velocity": ["numerical differentiation", "arrays", "finite differences"],
+    "ex4_1_read_constants": ["file reading", "dictionary construction", "string splitting"],
+    "ex4_2_reverse_dict": ["dictionary operations", "key-value swap", "dict comprehension"],
+    "ex4_3_triangle_area": ["geometry formula", "function definition", "math operations"],
+    "ex4_4_read_densities": ["file I/O", "dictionary", "data parsing"],
+    "ex4_5_class_F": ["class definition", "methods", "object-oriented programming"],
+    "ex4_6_simple_class": ["class definition", "__init__", "instance methods"],
+    "ex4_7_account_transactions": ["class design", "methods", "state management"],
+    "ex4_8_line_class": ["class definition", "mathematical operations", "method implementation"],
+    "ex4_9_quadratic_class": ["class definition", "quadratic formula", "methods"],
+}
+
+# ---------------------------------------------------------------------------
+# Parse LLM JSON responses safely
+# ---------------------------------------------------------------------------
+
+def parse_llm_json(text: str) -> dict:
+    """Extract JSON from LLM response, handling markdown code fences and thinking tags."""
+    if not text or not text.strip():
+        return {"score": 0.0, "error": "Empty LLM response"}
+    # Strip Qwen3 thinking tags if present
+    text = re.sub(r'<think>.*?</think>', '', text, flags=re.DOTALL).strip()
+    # Strip markdown code fences if present
+    if text.startswith("```"):
+        lines = text.split("\n")
+        if lines[0].startswith("```"):
+            lines = lines[1:]
+        if lines and lines[-1].strip() == "```":
+            lines = lines[:-1]
+        text = "\n".join(lines)
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        # Try to find JSON object in text
+        match = re.search(r'\{.*\}', text, re.DOTALL)
+        if match:
+            try:
+                return json.loads(match.group())
+            except json.JSONDecodeError:
+                pass
+        return {"score": 0.0, "error": "Failed to parse LLM response"}
+
+
+def safe_float(value, default: float = 0.0) -> float:
+    """Safely convert a value to float, returning default on failure."""
+    try:
+        v = float(value)
+        return max(0.0, min(1.0, v))  # Clamp to [0, 1]
+    except (TypeError, ValueError):
+        return default
+
+

--- a/rag-server/server.py
+++ b/rag-server/server.py
@@ -46,6 +46,7 @@ class IndexResponse(BaseModel):
 class QueryRequest(BaseModel):
     query: str
     top_k: int = 3
+    filter_exercises: bool = False
 class QueryResult(BaseModel):
     source: str
     title: str
@@ -100,25 +101,36 @@ def index_chunks(req: IndexRequest):
 @app.post("/query", response_model=QueryResponse)
 def query_chunks(req: QueryRequest):
     """Accept a query string, embed it, return top-K similar chunks."""
+    import re
     if collection.count() == 0:
         return QueryResponse(results=[])
     query_embedding = model.encode([req.query], show_progress_bar=False).tolist()
+    
+    # If filtering exercises, query more chunks so we have enough after filtering
+    fetch_k = min(req.top_k * 4 if req.filter_exercises else req.top_k, collection.count())
     results = collection.query(
         query_embeddings=query_embedding,
-        n_results=min(req.top_k, collection.count()),
+        n_results=fetch_k,
         include=["documents", "metadatas", "distances"],
     )
     query_results: list[QueryResult] = []
+    exercise_pattern = re.compile(r'^Exercise\s+\d', re.IGNORECASE)
+
     if results and results["ids"] and results["ids"][0]:
         for i in range(len(results["ids"][0])):
+            title = results["metadatas"][0][i].get("title", "")
+            if req.filter_exercises and exercise_pattern.match(title):
+                continue
             distance = results["distances"][0][i] if results["distances"] else 0
             similarity = 1.0 - distance
             query_results.append(QueryResult(
                 source=results["metadatas"][0][i].get("source", ""),
-                title=results["metadatas"][0][i].get("title", ""),
+                title=title,
                 content=results["documents"][0][i] if results["documents"] else "",
                 score=round(similarity, 4),
             ))
+            if len(query_results) >= req.top_k:
+                break
     return QueryResponse(results=query_results)
 
 # ---------------------------------------------------------------------------

--- a/rag-server/update_ragas.py
+++ b/rag-server/update_ragas.py
@@ -1,0 +1,31 @@
+import textwrap
+
+UNIFIED_EVALUATION_PROMPT = textwrap.dedent("""\
+You are an expert evaluator assessing an AI-generated answer for a programming exercise.
+
+## Information
+- Exercise ID: {exercise_id}
+- Title: {title}
+- Description: {description}
+- Key concepts needed: {concepts}
+
+## Retrieved Context (Top-K Chunks)
+{chunks_with_ranks}
+
+## AI-Generated Answer
+{answer}
+
+## Question
+{question}
+
+## Task
+Evaluate the AI-generated answer and retrieved context across 4 metrics (0.0 to 1.0).
+
+1. Faithfulness: Is the answer entirely supported by the retrieved context? (1.0 = fully supported, 0.0 = unsupported/hallucinated).
+2. Answer Relevancy: How well does the answer address the question? (1.0 = perfectly relevant).
+3. Context Recall: Does the context contain all necessary information to solve the exercise? (1.0 = covers all concepts).
+4. Context Precision: Are the most relevant chunks ranked at the top? (1.0 = highly relevant chunks are at rank 1).
+
+Respond ONLY with a JSON object in exactly this format (no markdown, no tags, no extra text):
+{{"faithfulness": 0.0, "answer_relevancy": 0.0, "context_recall": 0.0, "context_precision": 0.0, "reasoning": "brief explanation"}}
+""")

--- a/src/ragUtils.ts
+++ b/src/ragUtils.ts
@@ -445,15 +445,24 @@ export function retrieveContext(
   query: string,
   index: RagChunk[],
   topK: number = 3,
-  queryEmbedding?: number[]
+  queryEmbedding?: number[],
+  excludeExercises: boolean = false
 ): string {
   if (index.length === 0) return '';
+
+  let pool = index;
+  if (excludeExercises) {
+    const filtered = index.filter(c => !/^Exercise\s+\d/i.test(c.title));
+    if (filtered.length > 0) {
+      pool = filtered;
+    }
+  }
 
   let scored: { chunk: RagChunk; score: number }[];
 
   // Semantic mode: cosine similarity
-  if (queryEmbedding && queryEmbedding.length > 0 && index[0]?.embedding && index[0].embedding.length > 0) {
-    scored = index
+  if (queryEmbedding && queryEmbedding.length > 0 && pool[0]?.embedding && pool[0].embedding.length > 0) {
+    scored = pool
       .filter(c => c.embedding && c.embedding.length > 0)
       .map(chunk => ({
         chunk,
@@ -464,20 +473,20 @@ export function retrieveContext(
     const queryTokens = [...new Set(tokenize(query))];
     if (queryTokens.length === 0) return '';
 
-    const N = index.length;
+    const N = pool.length;
 
     // Pre-compute document frequency for each query token
     const df = new Map<string, number>();
     for (const token of queryTokens) {
       let count = 0;
-      for (const chunk of index) {
+      for (const chunk of pool) {
         if (chunk.tokens.includes(token)) count++;
       }
       df.set(token, count);
     }
 
     // Score each chunk
-    scored = index.map(chunk => {
+    scored = pool.map(chunk => {
       let score = 0;
       const chunkTokenSet = new Set(chunk.tokens);
       for (const token of queryTokens) {
@@ -541,15 +550,22 @@ export async function indexToChromaDB(repoPath: string, serverUrl: string): Prom
   });
   return resp.data.indexed || 0;
 }
+
 /**
  * Query the ChromaDB backend for relevant course materials.
  * Returns formatted context string matching the output format of retrieveContext().
  */
-export async function queryChromaDB(query: string, serverUrl: string, topK: number = 3): Promise<string> {
+export async function queryChromaDB(
+  query: string,
+  serverUrl: string,
+  topK: number = 3,
+  excludeExercises: boolean = false
+): Promise<string> {
   const url = serverUrl.replace(/\/$/, '');
   const resp = await axios.post(`${url}/query`, {
     query: query.substring(0, 2000),  // truncate long queries
     top_k: topK,
+    filter_exercises: excludeExercises,
   }, {
     headers: { 'Content-Type': 'application/json' },
     timeout: 30000,


### PR DESCRIPTION
[Fix] evaluation: address critical issues in Evaluation code:
- evaluate_ragas.py: Self-verify Faithfulness score by computing from the returned claims array instead of blindly trusting LLM score field
- evaluate_ragas.py: Self-verify Context Recall score by computing from the returned concepts array instead of blindly trusting score
- evaluate_ragas.py + consolidated: Skipped exercises (LLM timeout/error) are now excluded from mean instead of scored as 0.0, which was biasing averages downward
- evaluate_ragas_consolidated.py: Increase judge max_tokens from 300 to 800 to prevent thinking-model JSON truncation
- evaluate_ragas.py + consolidated: Replace greedy regex JSON extraction with balanced-brace parsing to avoid mismatch on nested braces in LLM reasoning text

[Fix] evaluation: address critical issues in Evaluation code:
- evaluate_rag.py: Hit@K ground truth upgraded from lecture-level to concept-level relevance (chunk must match both source lecture AND contain exercise concept keywords from EXERCISE_CONCEPTS).
- evaluate_rag.py: Implement MAP (Mean Average Precision) metric that was advertised in docstring but never computed.
- evaluate_rag.py: Hybrid latency now times the full end-to-end.

[Feat] evaluate_ragas_consolidated: Based on the evaluate_ragas, instead of running four separate LLM calls, using single API call to evaluate the four different metrics.
- Main RAGAs Evaluation
  - Load knowledge base and embeddings
  - Load benchmark queries
  - Define retrieval engines — scenario-dependent
  - Evaluate each engine across both scenarios
  - Print final summary table

[Feat] evaluate_ragas_consolidated: Based on the evaluate_ragas, instead of running four separate LLM calls, using single API call to evaluate the four different metrics.
- LLM API Client
- RAGAs Consolidated Metric Prompt (LLM-as-a-Judge)
- Answer Generation (simulate CellMate Pre-study Guide)
- Concept Extraction per Exercise (Ground Truth for Context Recall)
- Parse LLM JSON responses safely

[Fix] src/ragUtils.ts: retrieveContext() / queryChromaDB() supports excludeExercises
- update_ragas.py: UNIFIED_EVALUATION_PROMPT

[Fix] rag-server/server.py: The /query endpoint supports the filter_exercises parameter.
- rag-server/config.py: Enhanced ChromaDB's automatic error recovery and directory reset capabilities.

[Feat] Filter out Exercise description chunks, keeping only teaching content:
- Exercise chunks (titled 'Exercise X.Y: ...') contain only the problem
- statement and empty code scaffolding — no teaching value for Pre-study
- Guide generation. Removing them forces retrieval to surface the actual
- lecture explanation chunks (e.g. 'The while loop', 'Lists', etc.)

[Feat]: implement exercise chunk filtering for RAG retrieval and add RAGAs-based evaluation tools:
- Pre-compute teaching-only chunks (exclude Exercise descriptions)
- Embeddings for all chunks (used by AI Feedback scenario)
- Embeddings for teaching chunks only (used by Pre-study scenario)
- Query enhancement: append concept keywords for Pre-study
- Define retrieval engines — scenario-dependent
  - Pre-study: uses teaching_chunks (exercise descriptions filtered out), top_k=5
  - AI Feedback: uses all chunks (exercise context may help), top_k=5